### PR TITLE
Add Validate method for `xiond export`

### DIFF
--- a/x/abstractaccount/types/account.go
+++ b/x/abstractaccount/types/account.go
@@ -77,6 +77,14 @@ func (acc *AbstractAccount) SetSequence(seq uint64) error {
 	return nil
 }
 
+func (acc *AbstractAccount) Validate() error {
+	if len(acc.Address) == 0 {
+		return errors.New("address cannot be empty")
+	}
+
+	return nil
+}
+
 // --------------------------------- NilPubKey ---------------------------------
 
 func NewNilPubKey(bz []byte) *NilPubKey {


### PR DESCRIPTION
Fixes `xiond export`

Required for: https://github.com/burnt-labs/xion/pull/162

```
panic: interface conversion: *types.AbstractAccount is not types.GenesisAccount: missing method Validate

goroutine 31 [running]:
github.com/cosmos/cosmos-sdk/x/auth/keeper.AccountKeeper.ExportGenesis.func1({0x3f48b40?, 0xc0038d4160})
        github.com/cosmos/cosmos-sdk@v0.47.5/x/auth/keeper/genesis.go:43 +0x3d
github.com/cosmos/cosmos-sdk/x/auth/keeper.AccountKeeper.IterateAccounts({{0x3f14588, 0xc0013211e0}, {0x3f48520, 0xc000bf00c0}, 0xc001325f20, 0x3a12e60, {0x3f16a68, 0xc001321550}, {0xc00117e300, 0x2b}}, ...)
        github.com/cosmos/cosmos-sdk@v0.47.5/x/auth/keeper/account.go:104 +0x185
github.com/cosmos/cosmos-sdk/x/auth/keeper.AccountKeeper.ExportGenesis({{0x3f14588, 0xc0013211e0}, {0x3f48520, 0xc000bf00c0}, 0xc001325f20, 0x3a12e60, {0x3f16a68, 0xc001321550}, {0xc00117e300, 0x2b}}, ...)
        github.com/cosmos/cosmos-sdk@v0.47.5/x/auth/keeper/genesis.go:42 +0x165
github.com/cosmos/cosmos-sdk/x/auth.AppModule.ExportGenesis({{}, {{0x3f14588, 0xc0013211e0}, {0x3f48520, 0xc000bf00c0}, 0xc001325f20, 0x3a12e60, {0x3f16a68, 0xc001321550}, {0xc00117e300, ...}}, ...}, ...)
        github.com/cosmos/cosmos-sdk@v0.47.5/x/auth/module.go:162 +0x7c
github.com/cosmos/cosmos-sdk/types/module.(*Manager).ExportGenesisForModules.func1({0x7f092d31da58, 0xc0007cc310}, 0xc004717320?)
        github.com/cosmos/cosmos-sdk@v0.47.5/types/module/module.go:402 +0xf3
created by github.com/cosmos/cosmos-sdk/types/module.(*Manager).ExportGenesisForModules
        github.com/cosmos/cosmos-sdk@v0.47.5/types/module/module.go:400 +0x4b1
```