### PR TITLE
fix(abstractaccount): enforce AllowedCodeIDs on AA contract migration

### DIFF
--- a/simapp/ante.go
+++ b/simapp/ante.go
@@ -53,6 +53,11 @@ func NewAnteHandler(options AnteHandlerOptions) (sdk.AnteHandler, error) {
 		wasmkeeper.NewCountTXDecorator(options.TXCounterStoreKey),
 		ante.NewExtensionOptionsDecorator(options.ExtensionOptionChecker),
 		ante.NewValidateBasicDecorator(),
+		// Validate MsgMigrateContract for AbstractAccounts against AllowedCodeIDs
+		abstractaccount.NewMigrateValidationDecorator(
+			options.AbstractAccountKeeper,
+			options.AccountKeeper,
+		),
 		ante.NewTxTimeoutHeightDecorator(),
 		ante.NewValidateMemoDecorator(options.AccountKeeper),
 		ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),

--- a/x/abstractaccount/ante_migrate.go
+++ b/x/abstractaccount/ante_migrate.go
@@ -1,0 +1,78 @@
+package abstractaccount
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+
+	"github.com/burnt-labs/abstract-account/x/abstractaccount/keeper"
+	"github.com/burnt-labs/abstract-account/x/abstractaccount/types"
+)
+
+var _ sdk.AnteDecorator = &MigrateValidationDecorator{}
+
+// MigrateValidationDecorator validates that MsgMigrateContract for AbstractAccount
+// contracts only migrates to code IDs in the AllowedCodeIDs list.
+//
+// This prevents attackers from migrating AA contracts to malicious code if
+// code upload permissions are ever relaxed from "Nobody" to a more permissive
+// setting.
+type MigrateValidationDecorator struct {
+	aak keeper.Keeper
+	ak  authante.AccountKeeper
+}
+
+func NewMigrateValidationDecorator(aak keeper.Keeper, ak authante.AccountKeeper) MigrateValidationDecorator {
+	return MigrateValidationDecorator{aak: aak, ak: ak}
+}
+
+func (d MigrateValidationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	for _, msg := range tx.GetMsgs() {
+		migrateMsg, ok := msg.(*wasmtypes.MsgMigrateContract)
+		if !ok {
+			continue
+		}
+
+		// Check if contract is an AbstractAccount
+		contractAddr, err := sdk.AccAddressFromBech32(migrateMsg.Contract)
+		if err != nil {
+			return ctx, err
+		}
+
+		acc := d.ak.GetAccount(ctx, contractAddr)
+		if acc == nil {
+			continue
+		}
+
+		_, isAbstractAccount := acc.(*types.AbstractAccount)
+		if !isAbstractAccount {
+			continue
+		}
+
+		// Validate new code ID against AllowedCodeIDs
+		params, err := d.aak.GetParams(ctx)
+		if err != nil {
+			return ctx, err
+		}
+
+		if !params.AllowAllCodeIDs {
+			allowed := false
+			for _, codeID := range params.AllowedCodeIDs {
+				if codeID == migrateMsg.CodeID {
+					allowed = true
+					break
+				}
+			}
+			if !allowed {
+				return ctx, sdkerrors.ErrUnauthorized.Wrapf(
+					"cannot migrate AbstractAccount to code ID %d: not in AllowedCodeIDs",
+					migrateMsg.CodeID,
+				)
+			}
+		}
+	}
+
+	return next(ctx, tx, simulate)
+}

--- a/x/abstractaccount/ante_migrate_test.go
+++ b/x/abstractaccount/ante_migrate_test.go
@@ -1,0 +1,169 @@
+package abstractaccount_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	simapptesting "github.com/burnt-labs/abstract-account/simapp/testing"
+	"github.com/burnt-labs/abstract-account/x/abstractaccount"
+	"github.com/burnt-labs/abstract-account/x/abstractaccount/types"
+)
+
+func TestMigrateValidationDecorator(t *testing.T) {
+	app := simapptesting.MakeSimpleMockApp()
+	ctx := app.NewContext(false)
+
+	// Create an AbstractAccount with unique account number
+	absAccAddr := sdk.AccAddress([]byte("abstract-account-addr"))
+	absAcc := types.NewAbstractAccount(absAccAddr.String(), 100, 0)
+	app.AccountKeeper.SetAccount(ctx, absAcc)
+
+	// Create a regular account (non-AA) - use NewAccountWithAddress to let it assign account num
+	regularAccAddr := sdk.AccAddress([]byte("regular-account-addr1"))
+	regularAcc := app.AccountKeeper.NewAccountWithAddress(ctx, regularAccAddr)
+	app.AccountKeeper.SetAccount(ctx, regularAcc)
+
+	// Set params to only allow code ID 1 and 2
+	params, err := types.NewParams(false, []uint64{1, 2}, 1000000, 1000000)
+	require.NoError(t, err)
+	err = app.AbstractAccountKeeper.SetParams(ctx, params)
+	require.NoError(t, err)
+
+	decorator := abstractaccount.NewMigrateValidationDecorator(
+		app.AbstractAccountKeeper,
+		app.AccountKeeper,
+	)
+
+	for _, tc := range []struct {
+		desc           string
+		contractAddr   string
+		codeID         uint64
+		expOk          bool
+		expErrContains string
+	}{
+		{
+			desc:         "allowed code ID for AbstractAccount",
+			contractAddr: absAccAddr.String(),
+			codeID:       1,
+			expOk:        true,
+		},
+		{
+			desc:         "allowed code ID 2 for AbstractAccount",
+			contractAddr: absAccAddr.String(),
+			codeID:       2,
+			expOk:        true,
+		},
+		{
+			desc:           "disallowed code ID for AbstractAccount",
+			contractAddr:   absAccAddr.String(),
+			codeID:         999,
+			expOk:          false,
+			expErrContains: "not in AllowedCodeIDs",
+		},
+		{
+			desc:         "any code ID for regular account (not an AA)",
+			contractAddr: regularAccAddr.String(),
+			codeID:       999,
+			expOk:        true,
+		},
+		{
+			desc:         "unknown account address",
+			contractAddr: sdk.AccAddress([]byte("unknown-addr-here12")).String(),
+			codeID:       999,
+			expOk:        true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			msg := &wasmtypes.MsgMigrateContract{
+				Sender:   absAccAddr.String(),
+				Contract: tc.contractAddr,
+				CodeID:   tc.codeID,
+				Msg:      []byte("{}"),
+			}
+
+			txBuilder := app.TxConfig().NewTxBuilder()
+			require.NoError(t, txBuilder.SetMsgs(msg))
+			tx := txBuilder.GetTx()
+
+			_, err := decorator.AnteHandle(ctx, tx, false, anteTerminator)
+
+			if tc.expOk {
+				require.NoError(t, err, tc.desc)
+			} else {
+				require.Error(t, err, tc.desc)
+				if tc.expErrContains != "" {
+					require.Contains(t, err.Error(), tc.expErrContains, tc.desc)
+				}
+			}
+		})
+	}
+}
+
+func TestMigrateValidationDecorator_AllowAllCodeIDs(t *testing.T) {
+	app := simapptesting.MakeSimpleMockApp()
+	ctx := app.NewContext(false)
+
+	// Create an AbstractAccount with unique account number
+	absAccAddr := sdk.AccAddress([]byte("abstract-account-addr"))
+	absAcc := types.NewAbstractAccount(absAccAddr.String(), 200, 0)
+	app.AccountKeeper.SetAccount(ctx, absAcc)
+
+	// Set params to allow all code IDs
+	params, err := types.NewParams(true, []uint64{}, 1000000, 1000000)
+	require.NoError(t, err)
+	err = app.AbstractAccountKeeper.SetParams(ctx, params)
+	require.NoError(t, err)
+
+	decorator := abstractaccount.NewMigrateValidationDecorator(
+		app.AbstractAccountKeeper,
+		app.AccountKeeper,
+	)
+
+	msg := &wasmtypes.MsgMigrateContract{
+		Sender:   absAccAddr.String(),
+		Contract: absAccAddr.String(),
+		CodeID:   999, // Would be rejected if AllowAllCodeIDs was false
+		Msg:      []byte("{}"),
+	}
+
+	txBuilder := app.TxConfig().NewTxBuilder()
+	require.NoError(t, txBuilder.SetMsgs(msg))
+	tx := txBuilder.GetTx()
+
+	_, err = decorator.AnteHandle(ctx, tx, false, anteTerminator)
+	require.NoError(t, err)
+}
+
+func TestMigrateValidationDecorator_NonMigrateMsg(t *testing.T) {
+	app := simapptesting.MakeSimpleMockApp()
+	ctx := app.NewContext(false)
+
+	// Set restrictive params
+	params, err := types.NewParams(false, []uint64{1}, 1000000, 1000000)
+	require.NoError(t, err)
+	err = app.AbstractAccountKeeper.SetParams(ctx, params)
+	require.NoError(t, err)
+
+	decorator := abstractaccount.NewMigrateValidationDecorator(
+		app.AbstractAccountKeeper,
+		app.AccountKeeper,
+	)
+
+	// A non-migrate message should pass through
+	msg := &wasmtypes.MsgExecuteContract{
+		Sender:   sdk.AccAddress([]byte("sender-addr-here123")).String(),
+		Contract: sdk.AccAddress([]byte("contract-addr-here1")).String(),
+		Msg:      []byte("{}"),
+	}
+
+	txBuilder := app.TxConfig().NewTxBuilder()
+	require.NoError(t, txBuilder.SetMsgs(msg))
+	tx := txBuilder.GetTx()
+
+	_, err = decorator.AnteHandle(ctx, tx, false, anteTerminator)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

Mitigates SEC-73 risk by enforcing `AllowedCodeIDs` during `MsgMigrateContract` for AbstractAccount contracts.

### Changes

- Added `MigrateValidationDecorator` in `x/abstractaccount/ante_migrate.go`
  - Inspects `MsgMigrateContract` messages in ante
  - If target contract is an `AbstractAccount`, validates destination `CodeID` against module params
  - Rejects migration when `AllowAllCodeIDs=false` and `CodeID` is not in `AllowedCodeIDs`
- Wired decorator into ante chain in `simapp/ante.go`
- Added tests in `x/abstractaccount/ante_migrate_test.go`:
  - allowed code IDs pass
  - disallowed code IDs are rejected for AA contracts
  - `AllowAllCodeIDs=true` allows migration
  - non-AA contracts are not blocked
  - non-migration messages pass through

## Why

`AllowedCodeIDs` was enforced on registration but not migration. This creates a latent bypass if code upload permissions are ever relaxed.

## Test

- `go test ./...` passes locally