### PR TITLE
bump wasmd to v0.68.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 
 	// wasmd fork used by xion
-	github.com/CosmWasm/wasmd => github.com/burnt-labs/wasmd v0.61.9-xion.1
+	github.com/CosmWasm/wasmd => github.com/burnt-labs/wasmd v0.61.10-xion.1
 
 	// dgrijalva/jwt-go is deprecated and doesn't receive security updates.
 	// See: https://github.com/cosmos/cosmos-sdk/issues/13134
@@ -34,7 +34,7 @@ require (
 	cosmossdk.io/math v1.5.3
 	cosmossdk.io/store v1.1.2
 	cosmossdk.io/x/tx v0.14.0
-	github.com/CosmWasm/wasmd v0.61.8
+	github.com/CosmWasm/wasmd v0.61.10-xion.1
 	github.com/cometbft/cometbft v0.38.21
 	github.com/cosmos/cosmos-db v1.1.3
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5

--- a/go.sum
+++ b/go.sum
@@ -781,8 +781,8 @@ github.com/btcsuite/btcd/btcutil v1.1.6 h1:zFL2+c3Lb9gEgqKNzowKUPQNb8jV7v5Oaodi/
 github.com/btcsuite/btcd/btcutil v1.1.6/go.mod h1:9dFymx8HpuLqBnsPELrImQeTQfKBQqzqGbbV3jK55aE=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
-github.com/burnt-labs/wasmd v0.61.9-xion.1 h1:piOen/poPAjItEETKsxwNEMho1MwAn8zr4xSGTpkDBs=
-github.com/burnt-labs/wasmd v0.61.9-xion.1/go.mod h1:RV6F9S6oOevX6nL9PnSPtAee754ygYJ3JevzWL1vH5s=
+github.com/burnt-labs/wasmd v0.61.10-xion.1 h1:pywezDk4ukgdcxV5DQ89ceNoO276XvXhJHAMfjobtbw=
+github.com/burnt-labs/wasmd v0.61.10-xion.1/go.mod h1:RV6F9S6oOevX6nL9PnSPtAee754ygYJ3JevzWL1vH5s=
 github.com/butuzov/ireturn v0.3.0 h1:hTjMqWw3y5JC3kpnC5vXmFJAWI/m31jaCYQqzkS6PL0=
 github.com/butuzov/ireturn v0.3.0/go.mod h1:A09nIiwiqzN/IoVo9ogpa0Hzi9fex1kd9PSD6edP5ZA=
 github.com/butuzov/mirror v1.2.0 h1:9YVK1qIjNspaqWutSv8gsge2e/Xpq1eqEkslEUHy5cs=


### PR DESCRIPTION
This pull request updates the dependency on `github.com/CosmWasm/wasmd` to a newer custom fork version, aligning both the direct requirement and the replacement override in `go.mod`.

Dependency updates:

* Updated the `github.com/CosmWasm/wasmd` dependency from `v0.61.8` to the custom fork version `v0.61.10-xion.1` in the `require` section of `go.mod`.
* Updated the `replace` directive to point from `github.com/burnt-labs/wasmd v0.61.9-xion.1` to `v0.61.10-xion.1`, ensuring the project uses the latest forked release.